### PR TITLE
feat: Remove unused txHash parameter from consolidation and withdrawa…

### DIFF
--- a/script/MockData.s.sol
+++ b/script/MockData.s.sol
@@ -142,8 +142,7 @@ contract MockData is Script {
             "124wd5urvxo4H3naXR6QACP1MGVpLeikeR",
             1 ether,
             0.1 ether,
-            bytes32(uint256(0)),
-            "TxHash"
+            bytes32(uint256(0))
         );
 
         // consolidate
@@ -175,24 +174,21 @@ contract MockData is Script {
             TICKER,
             CHAIN_ID,
             1 ether,
-            bytes32(uint256(0)),
-            "consolidate txHash1"
+            bytes32(uint256(0))
         );
         fundsHandler.consolidate(
             "fromAddr2",
             TICKER,
             CHAIN_ID,
             2.5 ether,
-            bytes32(uint256(1)),
-            "consolidate txHash2"
+            bytes32(uint256(1))
         );
         fundsHandler.consolidate(
             "fromAddr3",
             TICKER,
             CHAIN_ID,
             3.3 ether,
-            bytes32(uint256(2)),
-            "consolidate txHash3"
+            bytes32(uint256(2))
         );
     }
 

--- a/src/handlers/FundsHandlerUpgradeable.sol
+++ b/src/handlers/FundsHandlerUpgradeable.sol
@@ -156,10 +156,7 @@ contract FundsHandlerUpgradeable is IFundsHandler, HandlerBase {
                     _params[i].toAddress,
                     _params[i].amount - withdrawFee,
                     withdrawFee,
-                    _params[i].salt,
-                    // offset for txHash
-                    // @dev "-1" if it is exact 32 bytes it does not take one extra slot
-                    uint256(320) + (32 * ((addrLength - 1) / 32))
+                    _params[i].salt
                 )
             );
         }
@@ -176,8 +173,7 @@ contract FundsHandlerUpgradeable is IFundsHandler, HandlerBase {
         string calldata _toAddress,
         uint256 _amount,
         uint256 _withdrawFee,
-        bytes32 _salt,
-        string calldata _txHash
+        bytes32 _salt
     ) external onlyRole(ENTRYPOINT_ROLE) validateAsset(_ticker, _chainId) {
         withdrawals[_userAddress].push(
             WithdrawalInfo(_userAddress, _chainId, _ticker, _toAddress, _amount, _salt)
@@ -213,12 +209,7 @@ contract FundsHandlerUpgradeable is IFundsHandler, HandlerBase {
                     _params[i].ticker,
                     _params[i].chainId,
                     _params[i].amount,
-                    _params[i].salt,
-                    // offset for txHash
-                    // @dev "-1" if it is exact 32 bytes it does not take one extra slot
-                    uint256(352) +
-                        (32 * ((fromAddrLength - 1) / 32)) +
-                        (32 * ((toAddrLength - 1) / 32))
+                    _params[i].salt
                 )
             );
         }
@@ -268,10 +259,7 @@ contract FundsHandlerUpgradeable is IFundsHandler, HandlerBase {
                     _params[i].ticker,
                     _params[i].chainId,
                     _params[i].amount,
-                    _params[i].salt,
-                    // offset for txHash
-                    // @dev "-1" if it is exact 32 bytes it does not take one extra slot
-                    uint256(256) + (32 * ((addrLength - 1) / 32))
+                    _params[i].salt
                 )
             );
         }
@@ -286,8 +274,7 @@ contract FundsHandlerUpgradeable is IFundsHandler, HandlerBase {
         bytes32 _ticker,
         uint64 _chainId,
         uint256 _amount,
-        bytes32 _salt,
-        string calldata _txHash
+        bytes32 _salt
     ) external onlyRole(ENTRYPOINT_ROLE) validateAsset(_ticker, _chainId) {
         consolidateRecords[_ticker][_chainId].push(
             ConsolidateTaskParam(_fromAddress, _ticker, _chainId, _amount, _salt)

--- a/src/interfaces/IFundsHandler.sol
+++ b/src/interfaces/IFundsHandler.sol
@@ -98,8 +98,7 @@ interface IFundsHandler {
         string calldata _toAddress,
         uint256 _amount,
         uint256 _withdrawFee,
-        bytes32 _salt,
-        string calldata _txHash
+        bytes32 _salt
     ) external;
 
     function getDeposits(address depositAddress) external view returns (DepositInfo[] memory);


### PR DESCRIPTION
The `txHash` parameter and related calculations were removed across multiple functions in favor of simplifying the implementation. This change reduces unnecessary complexity and optimizes the contract's storage and computation usage.